### PR TITLE
workflow: fixes for non-root runtime user

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,22 +157,23 @@ follows:
 
 .. code-block:: console
 
-   $ less environment/Dockerfile
-   # Start from the ROOT6 base image:
-   FROM reanahub/reana-env-root6
+    $ less environments/reana-demo-bsm-search/Dockerfile
+    # Start from the ROOT6 base image:
+    FROM reanahub/reana-env-root6:6.18.04
 
-   # Install HFtools:
-   RUN apt-get -y update && \
-       apt-get -y install \
-          python-pip \
-          zip && \
-       apt-get autoremove -y && \
-       apt-get clean -y
-   RUN pip install hftools
+    # Install HFtools and its dependencies:
+    RUN apt-get -y update && \
+        apt-get -y install \
+           libyaml-dev \
+           python-numpy \
+           zip && \
+        apt-get autoremove -y && \
+        apt-get clean -y
+    RUN pip install hftools==0.0.6
 
-   # Mount our code:
-   ADD code /code
-   WORKDIR /code
+    # Mount our code:
+    ADD code /code
+    WORKDIR /code
 
 We can build our analysis environment image and give it a name
 ``reanahub/reana-demo-bsm-search``:

--- a/code/hepdata_export.py
+++ b/code/hepdata_export.py
@@ -1,7 +1,10 @@
-import hftools.hepdata as hft_hepdata
-import yaml
+import os
 import sys
+
 import ROOT
+import yaml
+
+import hftools.hepdata as hft_hepdata
 
 main_submission = '''\
 ---
@@ -32,20 +35,27 @@ def main():
     ]
 
     rootfile = sys.argv[1]
+    try:
+        submission_yaml = sys.argv[2]
+    except:
+        submission_yaml = 'submission.yaml'
+    try:
+        data1_yaml = sys.argv[3]
+    except:
+        data1_yaml = 'data1.yaml'
     observable = 'x'
     channel = 'channel1'
     workspace = 'combined'
-    outputfile = 'data1.yaml'
 
     f  = ROOT.TFile.Open(str(rootfile))
     ws = f.Get(str(workspace))
 
     hepdata_table = hft_hepdata.hepdata_table(ws,channel,observable,sampledef)
 
-    with open('submission.yaml','w') as f:
+    with open(submission_yaml,'w') as f:
         f.write(main_submission)
 
-    with open(outputfile,'w') as f:
+    with open(data1_yaml,'w') as f:
         f.write(yaml.safe_dump(hepdata_table,default_flow_style = False))
 
 

--- a/environments/reana-demo-bsm-search/Dockerfile
+++ b/environments/reana-demo-bsm-search/Dockerfile
@@ -1,14 +1,15 @@
 # Start from the ROOT6 base image:
-FROM reanahub/reana-env-root6
+FROM reanahub/reana-env-root6:6.18.04
 
-# Install HFtools:
+# Install HFtools and its dependencies:
 RUN apt-get -y update && \
     apt-get -y install \
-       python-pip \
+       libyaml-dev \
+       python-numpy \
        zip && \
     apt-get autoremove -y && \
     apt-get clean -y
-RUN pip install hftools
+RUN pip install hftools==0.0.6
 
 # Mount our code:
 ADD code /code

--- a/reana.yaml
+++ b/reana.yaml
@@ -1,4 +1,4 @@
-version: 0.2.0
+version: 0.6.0
 inputs:
  parameters:
     nevents: 160000

--- a/workflow/databkgmc.yml
+++ b/workflow/databkgmc.yml
@@ -56,6 +56,8 @@ stages:
       scheduler_type: singlestep-stage
       parameters:
         combined_model: {stages: 'makews', output: workspace, unwrap: true}
+        nominal_vals: '{workdir}/nominal_vals.yml'
+        fit_results: '{workdir}/fit_results.yml'
         prefit_plot: '{workdir}/prefit.pdf'
         postfit_plot: '{workdir}/postfit.pdf'
       step: {$ref: workflow/steps.yml#/plot}
@@ -65,5 +67,7 @@ stages:
       scheduler_type: singlestep-stage
       parameters:
         combined_model: {stages: 'makews', output: workspace, unwrap: true}
-        hepdata_submission: '{workdir}/submission.zip'
+        hepdata_submission_zip: '{workdir}/submission.zip'
+        hepdata_submission_yaml: '{workdir}/submission.yaml'
+        hepdata_data1_yaml: '{workdir}/data1.yaml'
       step: {$ref: workflow/steps.yml#/hepdata}

--- a/workflow/steps.yml
+++ b/workflow/steps.yml
@@ -103,6 +103,7 @@ merge_root:
   environment:
     environment_type: docker-encapsulated
     image: reanahub/reana-env-root6
+    imagetag: 6.18.04
   publisher:
     publisher_type: 'frompar-pub'
     outputmap:
@@ -118,6 +119,7 @@ merge_root_allpars:
   environment:
     environment_type: docker-encapsulated
     image: reanahub/reana-env-root6
+    imagetag: 6.18.04
   publisher:
     publisher_type: 'frompar-pub'
     outputmap:
@@ -129,10 +131,10 @@ plot:
     interpreter: bash
     script: |
       source /usr/local/bin/thisroot.sh
-      hfquickplot write_vardef {combined_model} combined nominal_vals.yml
-      hfquickplot plot_channel {combined_model} combined channel1 x nominal_vals.yml -c qcd,mc2,mc1,signal -o {prefit_plot}
-      hfquickplot fit {combined_model} combined fitresults.yml
-      hfquickplot plot_channel {combined_model} combined channel1 x fitresults.yml -c qcd,mc2,mc1,signal -o {postfit_plot}
+      hfquickplot write-vardef {combined_model} combined {nominal_vals}
+      hfquickplot plot-channel {combined_model} combined channel1 x {nominal_vals} -c qcd,mc2,mc1,signal -o {prefit_plot}
+      hfquickplot fit {combined_model} combined {fit_results}
+      hfquickplot plot-channel {combined_model} combined channel1 x {fit_results} -c qcd,mc2,mc1,signal -o {postfit_plot}
   environment:
     environment_type: docker-encapsulated
     image: reanahub/reana-demo-bsm-search
@@ -148,12 +150,12 @@ hepdata:
     interpreter: bash
     script: |
       source /usr/local/bin/thisroot.sh
-      python /code/hepdata_export.py {combined_model}
-      zip {hepdata_submission} submission.yaml data1.yaml
+      python /code/hepdata_export.py {combined_model} {hepdata_submission_yaml} {hepdata_data1_yaml}
+      zip {hepdata_submission_zip} {hepdata_submission_yaml} {hepdata_data1_yaml}
   environment:
     environment_type: docker-encapsulated
     image: reanahub/reana-demo-bsm-search
   publisher:
     publisher_type: 'frompar-pub'
     outputmap:
-      hepdata_submission: 'hepdata_submission'
+      hepdata_submission_zip: 'hepdata_submission_zip'


### PR DESCRIPTION
* Upgrades to ROOT 6.18.04 and pins version.

* Upgrades to hftools 0.0.6 and pins version.

* Amends workflow definition to use workspace directory for all
  temporary files created by hstools anda hepdata last steps. Amends
  Python scripts accordingly. This fixes the permission problems where
  the workflow runtime user couldn't write to the current working
  directory after REANA policy change to use non-root users due to
  security concerns. (closes #14)

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>