### PR TITLE
reana.yaml: addition of workflow files as inputs

### DIFF
--- a/reana.yaml
+++ b/reana.yaml
@@ -1,4 +1,7 @@
 version: 0.6.0
+inputs:
+  directories:
+    - workflow
 workflow:
   type: yadage
   file: workflow/databkgmc.yml


### PR DESCRIPTION
* Following up the recent changes in REANA related to Yadage
  toplevel/initdir, all the workflow files must be declared as inputs.

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>