### PR TITLE
release: 1.0.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2018 CERN.
+Copyright (C) 2018, 2019, 2020 CERN.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -18,7 +18,3 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-In applying this license, CERN does not waive the privileges and
-immunities granted to it by virtue of its status as an
-Intergovernmental Organization or submit itself to any jurisdiction.

--- a/reana.yaml
+++ b/reana.yaml
@@ -7,4 +7,5 @@ workflow:
   file: workflow/databkgmc.yml
 outputs:
   files:
-   - outputs/plot/postfit.pdf
+   - plot/prefit.pdf
+   - plot/postfit.pdf

--- a/workflow/steps.yml
+++ b/workflow/steps.yml
@@ -8,6 +8,7 @@ generate:
   environment:
     environment_type: docker-encapsulated
     image: reanahub/reana-demo-bsm-search
+    imagetag: 1.0.0
   publisher:
     publisher_type: 'frompar-pub'
     outputmap:
@@ -23,6 +24,7 @@ select:
   environment:
     environment_type: docker-encapsulated
     image: reanahub/reana-demo-bsm-search
+    imagetag: 1.0.0
   publisher:
     publisher_type: 'frompar-pub'
     outputmap:
@@ -39,6 +41,7 @@ select_mc:
   environment:
     environment_type: docker-encapsulated
     image: reanahub/reana-demo-bsm-search
+    imagetag: 1.0.0
   publisher:
     publisher_type: 'frompar-pub'
     outputmap:
@@ -55,6 +58,7 @@ histogram:
   environment:
     environment_type: docker-encapsulated
     image: reanahub/reana-demo-bsm-search
+    imagetag: 1.0.0
   publisher:
     publisher_type: 'frompar-pub'
     outputmap:
@@ -72,6 +76,7 @@ histogram_shape:
   environment:
     environment_type: docker-encapsulated
     image: reanahub/reana-demo-bsm-search
+    imagetag: 1.0.0
   publisher:
     publisher_type: 'frompar-pub'
     outputmap:
@@ -87,6 +92,7 @@ makews:
   environment:
     environment_type: docker-encapsulated
     image: reanahub/reana-demo-bsm-search
+    imagetag: 1.0.0
   publisher:
     publisher_type: 'interpolated-pub'
     glob: True
@@ -138,6 +144,7 @@ plot:
   environment:
     environment_type: docker-encapsulated
     image: reanahub/reana-demo-bsm-search
+    imagetag: 1.0.0
   publisher:
     publisher_type: 'frompar-pub'
     outputmap:
@@ -155,6 +162,7 @@ hepdata:
   environment:
     environment_type: docker-encapsulated
     image: reanahub/reana-demo-bsm-search
+    imagetag: 1.0.0
   publisher:
     publisher_type: 'frompar-pub'
     outputmap:


### PR DESCRIPTION
Pushing semver-tagged 1.0.0 released to Docker Hub so that example would work on Kubernetes clusters not pulling `latest`, such as Kind.

- release: 1.0.0
- docs: fix LICENSE badge recognition on GitHub
- reana: fix output file path