### PR TITLE
docker: podman-friendly image locations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ developed using the experiment-internal software stack (e.g. CMSSW or the ATLAS
 Analysis Releases) and be based on C++ with many dependencies and require multiple
 container images. In this emulation we have two container images.
 
-1. A pure ROOT6 container image :code:`reanahub/reana-demo-bsm-search` used
+1. A pure ROOT6 container image :code:`docker.io/reanahub/reana-demo-bsm-search` used
    for most steps (such as selection, merging etc)
 2. An image based on ROOT6 which also has the :code:`hftools` package installed.
    This image is used for the last steps dealing with fitting, plotting and
@@ -162,7 +162,7 @@ follows:
 
     $ less environments/reana-demo-bsm-search/Dockerfile
     # Start from the ROOT6 base image:
-    FROM reanahub/reana-env-root6:6.18.04
+    FROM docker.io/reanahub/reana-env-root6:6.18.04
 
     # Install HFtools and its dependencies:
     RUN apt-get -y update && \
@@ -179,17 +179,17 @@ follows:
     WORKDIR /code
 
 We can build our analysis environment image and give it a name
-``reanahub/reana-demo-bsm-search``:
+``docker.io/reanahub/reana-demo-bsm-search``:
 
 .. code-block:: console
 
-   $ docker build -f environment/Dockerfile -t reanahub/reana-demo-bsm-search .
+   $ docker build -f environment/Dockerfile -t docker.io/reanahub/reana-demo-bsm-search .
 
 We can push the image to the DockerHub image registry:
 
 .. code-block:: console
 
-   $ docker push reanahub/reana-demo-bsm-search
+   $ docker push docker.io/reanahub/reana-demo-bsm-search
 
 (Note that typically you would use your own username such as ``johndoe`` in
 place of ``reanahub``.)

--- a/environments/reana-demo-bsm-search/Dockerfile
+++ b/environments/reana-demo-bsm-search/Dockerfile
@@ -1,5 +1,5 @@
 # Start from the ROOT6 base image:
-FROM reanahub/reana-env-root6:6.18.04
+FROM docker.io/reanahub/reana-env-root6:6.18.04
 
 # Install HFtools and its dependencies:
 RUN apt-get -y update && \

--- a/workflow/steps.yml
+++ b/workflow/steps.yml
@@ -7,7 +7,7 @@ generate:
       python /code/generantuple.py {type} {nevents} {outputfile}
   environment:
     environment_type: docker-encapsulated
-    image: reanahub/reana-demo-bsm-search
+    image: docker.io/reanahub/reana-demo-bsm-search
     imagetag: 1.0.0
   publisher:
     publisher_type: 'frompar-pub'
@@ -23,7 +23,7 @@ select:
       python /code/select.py {inputfile} {outputfile} {region} nominal
   environment:
     environment_type: docker-encapsulated
-    image: reanahub/reana-demo-bsm-search
+    image: docker.io/reanahub/reana-demo-bsm-search
     imagetag: 1.0.0
   publisher:
     publisher_type: 'frompar-pub'
@@ -40,7 +40,7 @@ select_mc:
       python /code/select.py {inputfile} {outputfile} {region} $variations
   environment:
     environment_type: docker-encapsulated
-    image: reanahub/reana-demo-bsm-search
+    image: docker.io/reanahub/reana-demo-bsm-search
     imagetag: 1.0.0
   publisher:
     publisher_type: 'frompar-pub'
@@ -57,7 +57,7 @@ histogram:
       python /code/histogram.py {inputfile} {outputfile} {name} {weight} $variations
   environment:
     environment_type: docker-encapsulated
-    image: reanahub/reana-demo-bsm-search
+    image: docker.io/reanahub/reana-demo-bsm-search
     imagetag: 1.0.0
   publisher:
     publisher_type: 'frompar-pub'
@@ -75,7 +75,7 @@ histogram_shape:
       python /code/histogram.py {inputfile} {outputfile} $name {weight} $variations '{{name}}'
   environment:
     environment_type: docker-encapsulated
-    image: reanahub/reana-demo-bsm-search
+    image: docker.io/reanahub/reana-demo-bsm-search
     imagetag: 1.0.0
   publisher:
     publisher_type: 'frompar-pub'
@@ -91,7 +91,7 @@ makews:
       python /code/makews.py {data_bkg_hists} {workspace_prefix} {xml_dir}
   environment:
     environment_type: docker-encapsulated
-    image: reanahub/reana-demo-bsm-search
+    image: docker.io/reanahub/reana-demo-bsm-search
     imagetag: 1.0.0
   publisher:
     publisher_type: 'interpolated-pub'
@@ -108,7 +108,7 @@ merge_root:
       hadd {mergedfile} {inputs}
   environment:
     environment_type: docker-encapsulated
-    image: reanahub/reana-env-root6
+    image: docker.io/reanahub/reana-env-root6
     imagetag: 6.18.04
   publisher:
     publisher_type: 'frompar-pub'
@@ -124,7 +124,7 @@ merge_root_allpars:
       hadd {mergedfile} {signal} {data} {background}
   environment:
     environment_type: docker-encapsulated
-    image: reanahub/reana-env-root6
+    image: docker.io/reanahub/reana-env-root6
     imagetag: 6.18.04
   publisher:
     publisher_type: 'frompar-pub'
@@ -143,7 +143,7 @@ plot:
       hfquickplot plot-channel {combined_model} combined channel1 x {fit_results} -c qcd,mc2,mc1,signal -o {postfit_plot}
   environment:
     environment_type: docker-encapsulated
-    image: reanahub/reana-demo-bsm-search
+    image: docker.io/reanahub/reana-demo-bsm-search
     imagetag: 1.0.0
   publisher:
     publisher_type: 'frompar-pub'
@@ -161,7 +161,7 @@ hepdata:
       zip {hepdata_submission_zip} {hepdata_submission_yaml} {hepdata_data1_yaml}
   environment:
     environment_type: docker-encapsulated
-    image: reanahub/reana-demo-bsm-search
+    image: docker.io/reanahub/reana-demo-bsm-search
     imagetag: 1.0.0
   publisher:
     publisher_type: 'frompar-pub'


### PR DESCRIPTION
Adds fully qualified canonical locations of container images, making the container technology setup podman-friendly.

Closes reanahub/reana#729.